### PR TITLE
Fix weird error on latest flutter master channel; Still looks broken

### DIFF
--- a/lib/src/badge.dart
+++ b/lib/src/badge.dart
@@ -3,6 +3,7 @@ import 'package:badges/src/badge_position.dart';
 import 'package:badges/src/badge_positioned.dart';
 import 'package:badges/src/badge_shape.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
 class Badge extends StatefulWidget {
   final Widget badgeContent;


### PR DESCRIPTION
```
Launching lib/main.dart on Pixel 3 XL in debug mode...
Compiler message:
../../../.pub-cache/hosted/pub.dartlang.org/badges-1.1.1/lib/src/badge.dart:83:19: Error: The getter 'Overflow' isn't defined for the class 'BadgeState'.
 - 'BadgeState' is from 'package:badges/src/badge.dart' ('../../../.pub-cache/hosted/pub.dartlang.org/badges-1.1.1/lib/src/badge.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'Overflow'.
        overflow: Overflow.visible,
                  ^^^^^^^^
Compiler message:
../../../.pub-cache/hosted/pub.dartlang.org/badges-1.1.1/lib/src/badge.dart:83:19: Error: The getter 'Overflow' isn't defined for the class 'BadgeState'.
 - 'BadgeState' is from 'package:badges/src/badge.dart' ('../../../.pub-cache/hosted/pub.dartlang.org/badges-1.1.1/lib/src/badge.dart').
Try correcting the name to the name of an existing getter, or defining a getter or field named 'Overflow'.
        overflow: Overflow.visible,
                  ^^^^^^^^
Target kernel_snapshot failed: Exception: Errors during snapshot creation: null
build failed.
FAILURE: Build failed with an exception.
* Where:
Script '/Users/USER/flutter/packages/flutter_tools/gradle/flutter.gradle' line: 896
* What went wrong:
Execution failed for task ':app:compileFlutterBuildDebug'.
> Process 'command '/Users/USER/flutter/bin/flutter'' finished with non-zero exit value 1
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 30s
Exception: Gradle task assembleDebug failed with exit code 1
Exited (sigterm)
```