### PR TITLE
Fix for deprecated overflow parameter on Stack widget

### DIFF
--- a/lib/src/badge.dart
+++ b/lib/src/badge.dart
@@ -80,7 +80,7 @@ class BadgeState extends State<Badge> with SingleTickerProviderStateMixin {
     } else {
       return Stack(
         alignment: widget.alignment,
-        overflow: Overflow.visible,
+        clipBehavior: Clip.none,
         children: [
           widget.child,
           BadgePositioned(


### PR DESCRIPTION
Fix for "No named parameter with the name 'overflow'" error.
Related to issue: https://github.com/yako-dev/flutter_badges/issues/27
Related to flutter core updates: https://github.com/flutter/flutter/commit/7948a7863bd8931e4e029c5b109f26c1b3dcf8ea