### PR TITLE
In the latest flutter master channel, the overflow parameter is gone, breaking builds.

### DIFF
--- a/lib/src/badge.dart
+++ b/lib/src/badge.dart
@@ -80,7 +80,6 @@ class BadgeState extends State<Badge> with SingleTickerProviderStateMixin {
     } else {
       return Stack(
         alignment: widget.alignment,
-        overflow: Overflow.visible,
         children: [
           widget.child,
           BadgePositioned(


### PR DESCRIPTION
Simply removing the overflow fixes that, without functionally changing badges, at least on my version of flutter:

Flutter Channel master, 1.22.0-10.0.pre.251