### PR TITLE
Stable null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.0] - [April 20, 2021]
+* Stable null safety
+
 ## [2.0.0-nullsafety.1] - [March 13, 2021]
 * Null safety, finally! Prerelease
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: badges
 description: A flutter package for creating badges. Badges can be used for an additional marker for any widget, e.g. show a number of items in a shopping cart.
-version: 2.0.0-nullsafety.1
+version: 2.0.0
 homepage: https://github.com/yadaniyil/flutter_badges
 
 dependencies:


### PR DESCRIPTION
Prerelease is needed anymore.

Could you merge this and run `dart pub publish`?