### PR TITLE
Fix bug : Rectangle badge sticks out when using bordar Radius and gradient

### DIFF
--- a/lib/src/badge.dart
+++ b/lib/src/badge.dart
@@ -227,12 +227,16 @@ class BadgeState extends State<Badge> with SingleTickerProviderStateMixin {
           shape: border,
           elevation: widget.elevation,
           child: Container(
-            decoration: BoxDecoration(
-              gradient: widget.gradient,
-              shape: widget.shape == BadgeShape.circle
-                  ? BoxShape.circle
-                  : BoxShape.rectangle,
-            ),
+            decoration: widget.shape == BadgeShape.circle
+                ? BoxDecoration(
+                    gradient: widget.gradient,
+                    shape: BoxShape.circle,
+                  )
+                : BoxDecoration(
+                    gradient: widget.gradient,
+                    shape: BoxShape.rectangle,
+                    borderRadius: widget.borderRadius,
+                  ),
             child: Padding(
               padding: widget.padding,
               child: widget.badgeContent,


### PR DESCRIPTION
## Description
Rectangle badge sticks out when using bordar Radius and gradient.

<img width="65" alt="スクリーンショット 2022-03-11 16 01 11" src="https://user-images.githubusercontent.com/84505829/157826607-765ccfc6-7d90-4686-b25b-669508c4aedd.png">

code
```
Badge(
  badgeContent: const Text('New'),
  child: const Icon(
    Icons.mail,
    color: Colors.black,
    size:50,
  ),
  gradient: const LinearGradient(colors:[ Colors.blue,Colors.red]),
  shape: BadgeShape.square,
  borderRadius: BorderRadius.circular(10),
  borderSide: const BorderSide(width: 3),
),
```

So, I fix it.

I added borderRadius in BoxDecoration in _badgeViewGradient() in lib/src/badge.dart.

After code modification
<img width="66" alt="スクリーンショット 2022-03-11 16 43 24" src="https://user-images.githubusercontent.com/84505829/157826957-30219f0e-4fdb-45bd-ab51-f848c1a8208a.png">

Please confirm this changes.

Thank you.
