### PR TITLE
fix: Unable to set transparent badge #100

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ unlinked_spec.ds
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+example/.flutter-plugins-dependencies
+example/.flutter-plugins-dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,3 @@ unlinked_spec.ds
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 example/.flutter-plugins-dependencies
-example/.flutter-plugins-dependencies

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -213,6 +213,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -249,6 +250,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/src/badge.dart
+++ b/lib/src/badge.dart
@@ -190,6 +190,8 @@ class BadgeState extends State<Badge> with TickerProviderStateMixin {
                 : Material(
                     shape: border,
                     elevation: widget.badgeStyle.elevation,
+                    // Without this Colors.transparent will be ignored
+                    type: MaterialType.transparency,
                     child: AnimatedContainer(
                       curve: widget.badgeAnimation.colorChangeAnimationCurve,
                       duration: widget.badgeAnimation.toAnimate

--- a/test/badges_test.dart
+++ b/test/badges_test.dart
@@ -343,6 +343,7 @@ void main() {
         shape: badges.BadgeShape.square,
         borderRadius: BorderRadius.circular(5),
         padding: const EdgeInsets.all(2),
+        badgeColor: Colors.transparent,
         badgeGradient: const badges.BadgeGradient.linear(
           colors: [
             Colors.blue,
@@ -390,6 +391,17 @@ void main() {
       await tester.pumpWidget(_wrapWithMaterialApp(badge));
 
       expect(find.text('MUSIC'), findsOneWidget);
+    });
+
+    testWidgets('Badge background color should match', (tester) async {
+      await tester.pumpWidget(_wrapWithMaterialApp(badge));
+
+      final badgeWidget =
+          tester.widget<badges.Badge>(find.byType(badges.Badge));
+      expect(
+        badgeWidget.badgeStyle.badgeColor,
+        Colors.transparent,
+      );
     });
 
     testWidgets('Badge gradient colors should match', (tester) async {


### PR DESCRIPTION
Add MaterialType.transparency to the Material widget to make Colors.transparent work on badge